### PR TITLE
Declare queue and exchange before use them

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,11 +51,11 @@ wisembly_amqp:
 
         # Prototype
         name:
-            host:                 ~ # Required
-            port:                 ~ # Required
-            login:                ~ # Required
-            password:             ~ # Required
-            vhost:                /
+            host:                  ~ # Required
+            port:                  ~ # Required
+            login:                 ~ # Required
+            password:              ~ # Required
+            vhost:                 /
 
     # Access gate for each dialog with AMQP
     gates:
@@ -64,16 +64,34 @@ wisembly_amqp:
         name:
 
             # Connection to use with this gate
-            connection:           null
+            connection:            null
+
+            # Does the queue and the exchange be declared before use them
+            auto_declare:          true
 
             # Exchange point associated to this gate
-            exchange:             ~ # Required
+            exchange:
+                name:               ~ # Required
+                options:
+                    type:           direct
+                    passive:        false
+                    durable:        true
+                    auto_delete:    false
+                    internal:       false
+                    arguments:      {  }
 
             # Routing key to use when sending messages through this gate
-            routing_key:          null
+            routing_key:            null
 
             # Queue to fetch the information from
-            queue:                ~ # Required
+            queue:
+                name:               ~ # Required
+                options:
+                    passive:        false
+                    durable:        true
+                    exclusive:      false
+                    auto_delete:    false
+                    arguments:      { }
 ```
 
 Usage
@@ -115,7 +133,7 @@ and use whatever you need !
 
 ### Consuming a Message
 In order to consume the messages that are expected by this bundle, all you have
-to do is run the following command : 
+to do is run the following command :
 
 ```
 php app/console wisembly:amqp:consume gate
@@ -129,7 +147,7 @@ to treat it, and will pass the environment and verbosity to the command that is
 runned. The output will then be retrieved and printed on the consumer's output.
 
 ### Implementing a Broker
-Two brokers are built-in : 
+Two brokers are built-in :
 
 - the `pecl` ([php amqp extension](https://pecl.php.net/package/amqp)) ;
 - [`oldsound`](https://github.com/videlalvaro/php-amqplib), which is the one

--- a/src/DependencyInjection/Compiler/GatePass.php
+++ b/src/DependencyInjection/Compiler/GatePass.php
@@ -43,12 +43,12 @@ class GatePass implements CompilerPassInterface
             $gate
                 ->addArgument($connections[$config['connection']])
                 ->addArgument($name)
-                ->addArgument($config['exchange'])
-                ->addArgument($config['queue'])
+                ->addArgument($config['exchange']['name'])
+                ->addArgument($config['queue']['name'])
                 ->addArgument($config['routing_key'])
                 ->addArgument($config['auto_declare'])
-                ->addArgument($config['queue_options'])
-                ->addArgument($config['exchange_options']);
+                ->addArgument($config['queue']['options'])
+                ->addArgument($config['exchange']['options']);
 
             $definition->addMethodCall('add', [new Reference($id)]);
         }

--- a/src/DependencyInjection/Compiler/GatePass.php
+++ b/src/DependencyInjection/Compiler/GatePass.php
@@ -45,10 +45,12 @@ class GatePass implements CompilerPassInterface
                 ->addArgument($name)
                 ->addArgument($config['exchange'])
                 ->addArgument($config['queue'])
-                ->addArgument($config['routing_key']);
+                ->addArgument($config['routing_key'])
+                ->addArgument($config['auto_declare'])
+                ->addArgument($config['queue_options'])
+                ->addArgument($config['exchange_options']);
 
             $definition->addMethodCall('add', [new Reference($id)]);
         }
     }
 }
-

--- a/src/DependencyInjection/Configuration.php
+++ b/src/DependencyInjection/Configuration.php
@@ -63,13 +63,57 @@ class Configuration implements ConfigurationInterface
                     ->canBeUnset()
                     ->prototype('array')
                         ->children()
+                            ->booleanNode('auto_declare')->info('Does the queue and the exchange be declared before use them')->defaultTrue()->end()
                             ->scalarNode('connection')->info('Connection to use with this gate')->defaultNull()->end()
                             ->scalarNode('exchange')->info('Exchange point associated to this gate')->isRequired()->end()
                             ->scalarNode('routing_key')->info('Routing key to use when sending messages through this gate')->defaultNull()->end()
                             ->scalarNode('queue')->info('Queue to fetch the information from')->isRequired()->end()
+                            ->append($this->queueOptions())
+                            ->append($this->exchangeOptions())
                         ->end()
                     ->end()
                 ->end()
             ->end();
+    }
+
+    private function queueOptions()
+    {
+        $builder = new TreeBuilder();
+        $node = $builder->root('queue_options');
+
+        $node->info('Broker options to declare the queue')
+            ->children()
+                ->booleanNode('passive')->defaultFalse()->end()
+                ->booleanNode('durable')->defaultTrue()->end()
+                ->booleanNode('exclusive')->defaultFalse()->end()
+                ->booleanNode('auto_delete')->defaultFalse()->end()
+                ->arrayNode('arguments')
+                    ->useAttributeAsKey('name')
+                    ->prototype('scalar')->end()
+                ->end()
+            ->end();
+
+        return $node;
+    }
+
+    private function exchangeOptions()
+    {
+        $builder = new TreeBuilder();
+        $node = $builder->root('exchange_options');
+
+        $node->info('Broker options to declare the exchange')
+            ->children()
+                ->scalarNode('type')->defaultFalse()->end()
+                ->booleanNode('passive')->defaultFalse()->end()
+                ->booleanNode('durable')->defaultTrue()->end()
+                ->booleanNode('auto_delete')->defaultFalse()->end()
+                ->booleanNode('internal')->defaultFalse()->end()
+                ->arrayNode('arguments')
+                    ->useAttributeAsKey('name')
+                    ->prototype('scalar')->end()
+                ->end()
+            ->end();
+
+        return $node;
     }
 }

--- a/src/Gate.php
+++ b/src/Gate.php
@@ -14,8 +14,14 @@ class Gate
     /** @var string Exchange to use */
     private $exchange;
 
+    /** @var array */
+    private $exchangeOptions;
+
     /** @var string Queue to use */
     private $queue;
+
+    /** @var array */
+    private $queueOptions;
 
     /** @var Connection Connection to use */
     private $connection;
@@ -23,19 +29,33 @@ class Gate
     /** @var string Routing key */
     private $key = null;
 
+    /** @var boolean Should we declare queue and exchange befor use */
+    private $autoDeclare;
+
     /**
      * @param string $name Gate's name
      * @param string $exchange Exchange's name
      * @param string $queue Queue's name
      * @param string|null $key routing key to use
      */
-    public function __construct(Connection $connection, $name, $exchange, $queue, $key = null)
-    {
+    public function __construct(
+        Connection $connection,
+        $name,
+        $exchange,
+        $queue,
+        $key = null,
+        $autoDeclare = true,
+        array $queueOptions = [],
+        array $exchangeOptions = []
+    ) {
         $this->key = $key;
         $this->name = $name;
         $this->queue = $queue;
         $this->exchange = $exchange;
         $this->connection = $connection;
+        $this->autoDeclare = $autoDeclare;
+        $this->queueOptions = $queueOptions;
+        $this->exchangeOptions = $exchangeOptions;
     }
 
     /** @return string Gate's name */
@@ -67,5 +87,22 @@ class Gate
     {
         return $this->connection;
     }
-}
 
+    /** @return array */
+    public function getQueueOptions()
+    {
+        return $this->queueOptions;
+    }
+
+    /** @return array */
+    public function getExchangeOptions()
+    {
+        return $this->exchangeOptions;
+    }
+
+    /** @return boolean */
+    public function getAutoDeclare()
+    {
+        return $this->autoDeclare;
+    }
+}


### PR DESCRIPTION
> Declaring a queue is idempotent - it will only be created if it doesn't exist already.
https://www.rabbitmq.com/tutorials/tutorial-one-php.html

This PR aims to add configuration need to declare the queue and the exchange of a gate and bind them together before using a producer or a consumer.

* [x] add the new configuration options
* [x] add a declare step with oldsound broker
* [x] add a declare step with amqp ext
* [x] update the readme

New configuration format

```yaml
# Current configuration for "WisemblyAmqpBundle"
# ==============================================

wisembly_amqp:
    default_connection: default
    broker: oldsound
    connections:
        default:
            host: amqp
            port: 5672
            login: guest
            password: guest
            vhost: /
    gates:
        mailing:
            auto_declare: true
            connection: default
            exchange: 
                name: mailing
                options:
                    type: direct
                    passive: false
                    durable: true
                    auto_delete: false
                    internal: false
                    arguments: {  }
            routing_key: mailing
            queue: 
                name: mailing
                options:
                    passive: false
                    durable: true
                    exclusive: false
                    auto_delete: false
                    arguments: { }
```