### PR TITLE
Transform the consume command to a service

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -13,9 +13,7 @@
         "symfony/console": "^3.0",
         "symfony/process": "^3.0",
         "symfony/filesystem": "^3.0",
-        "symfony/templating": "^3.0",
-
-        "symfony/framework-bundle": "^3.0"
+        "symfony/templating": "^3.0"
     },
 
     "require-dev": {

--- a/src/DependencyInjection/Configuration.php
+++ b/src/DependencyInjection/Configuration.php
@@ -41,6 +41,11 @@ class Configuration implements ConfigurationInterface
                     ->isRequired()
                 ->end()
 
+                ->scalarNode('console_path')
+                    ->info('Path to sf console binary')
+                    ->isRequired()
+                ->end()
+
                 ->arrayNode('connections')
                     ->info('Connections to AMQP to use')
                     ->useAttributeAsKey('name')

--- a/src/DependencyInjection/WisemblyAmqpExtension.php
+++ b/src/DependencyInjection/WisemblyAmqpExtension.php
@@ -27,6 +27,8 @@ class WisemblyAmqpExtension extends Extension
         $loader = new Loader\XmlFileLoader($container, new FileLocator(__DIR__.'/../Resources/config'));
 
         $this->loadAmqpConfiguration($container, $loader, $config);
+
+        $loader->load('commands.xml');
     }
 
     private function loadAmqpConfiguration(ContainerBuilder $container, Loader\FileLoader $loader, array $configuration)

--- a/src/DependencyInjection/WisemblyAmqpExtension.php
+++ b/src/DependencyInjection/WisemblyAmqpExtension.php
@@ -56,6 +56,8 @@ class WisemblyAmqpExtension extends Extension
             $container->setParameter('wisembly.amqp.' . $key, $value);
         }
 
+        $container->setParameter('wisembly.amqp.console__path', $configuration['console_path']);
+
         $loader->load('rabbitmq.xml');
     }
 }

--- a/src/Publisher.php
+++ b/src/Publisher.php
@@ -34,4 +34,3 @@ class Publisher
         $this->dispatcher->dispatch(MessagePublishedEvent::NAME, new MessagePublishedEvent($message, new Datetime, $gate));
     }
 }
-

--- a/src/Resources/config/commands.xml
+++ b/src/Resources/config/commands.xml
@@ -1,0 +1,22 @@
+<?xml version="1.0" ?>
+
+<container xmlns="http://symfony.com/schema/dic/services"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://symfony.com/schema/dic/services http://symfony.com/schema/dic/services/services-1.0.xsd">
+
+    <services>
+        <service id="wisembly.amqp.command.consumer" class="Wisembly\AmqpBundle\Command\ConsumerCommand">
+            <argument type="service" id="logger" on-invalid="null" />
+            <argument type="service" id="wisembly.amqp.broker" />
+            <argument type="service" id="wisembly.amqp.gates" />
+            <argument>%kernel.root_dir%/%wisembly.amqp.console_path%"</argument>
+            <tag name="console.command" />
+        </service>
+
+        <service id="wisembly.amqp.command.publisher" class="Wisembly\AmqpBundle\Command\PublishCommand">
+            <argument type="service" id="wismebly.amqp.publisher" />
+            <argument type="service" id="wisembly.amqp.gates" />
+            <tag name="console.command" />
+        </service>
+    </services>
+</container>

--- a/src/Resources/config/rabbitmq.xml
+++ b/src/Resources/config/rabbitmq.xml
@@ -28,6 +28,13 @@
         </service>
 
         <service id="wisembly.amqp.gates" class="Wisembly\AmqpBundle\GatesBag" />
+
+        <service id="wisembly.amqp.command.consumer" class="Wisembly\AmqpBundle\Command\ConsumerCommand">
+            <argument type="service" id="logger" on-invalid="null" />
+            <argument type="service" id="wisembly.amqp.broker" />
+            <argument type="service" id="wisembly.amqp.gates" />
+            <argument>%kernel.root_dir%/%wisembly.amqp.console_path%"</argument>
+            <tag name="console.command" />
+        </service>
     </services>
 </container>
-

--- a/src/Resources/config/rabbitmq.xml
+++ b/src/Resources/config/rabbitmq.xml
@@ -36,5 +36,11 @@
             <argument>%kernel.root_dir%/%wisembly.amqp.console_path%"</argument>
             <tag name="console.command" />
         </service>
+
+        <service id="wisembly.amqp.command.publisher" class="Wisembly\AmqpBundle\Command\PublishCommand">
+            <argument type="service" id="wismebly.amqp.publisher" />
+            <argument type="service" id="wisembly.amqp.gates" />
+            <tag name="console.command" />
+        </service>
     </services>
 </container>

--- a/src/Resources/config/rabbitmq.xml
+++ b/src/Resources/config/rabbitmq.xml
@@ -28,19 +28,5 @@
         </service>
 
         <service id="wisembly.amqp.gates" class="Wisembly\AmqpBundle\GatesBag" />
-
-        <service id="wisembly.amqp.command.consumer" class="Wisembly\AmqpBundle\Command\ConsumerCommand">
-            <argument type="service" id="logger" on-invalid="null" />
-            <argument type="service" id="wisembly.amqp.broker" />
-            <argument type="service" id="wisembly.amqp.gates" />
-            <argument>%kernel.root_dir%/%wisembly.amqp.console_path%"</argument>
-            <tag name="console.command" />
-        </service>
-
-        <service id="wisembly.amqp.command.publisher" class="Wisembly\AmqpBundle\Command\PublishCommand">
-            <argument type="service" id="wismebly.amqp.publisher" />
-            <argument type="service" id="wisembly.amqp.gates" />
-            <tag name="console.command" />
-        </service>
     </services>
 </container>


### PR DESCRIPTION
Ref #15 

- [x] Transform the consume command to a command as a service
- [x] Add a config for the console path
- [x] Transform the publish command to a command as a service
- [x] Remove dependency on Framework Bundle ?
- ~~Add some sort of configuration to determine which logger to use~~ later