### PR TITLE
Refactoring services

### DIFF
--- a/README.md
+++ b/README.md
@@ -159,8 +159,8 @@ runned. The output will then be retrieved and printed on the consumer's output.
 Two brokers are built-in :
 
 - the `pecl` ([php amqp extension](https://pecl.php.net/package/amqp)) ;
-- [`oldsound`](https://github.com/videlalvaro/php-amqplib), which is the one
-  implemented in full PHP by @videlalvaro
+- [`php-amqplib`](https://github.com/php-amqplib/php-amqplib), which is the one
+  implemented in full PHP
 
 The recommended broker is to use if available the `pecl` broker.
 

--- a/README.md
+++ b/README.md
@@ -110,17 +110,20 @@ or publish to one. For that, see below.
 
 ### Publishing a Message
 You may publish a new message to a gate (access point). For that, you should
-retrieve the services `wisembly.amqp.gates` to fetch the right gate, and then
-use the `wisembly.amqp.publisher` service to publish a message that can be
-understood by the `CommandProcessor` :
+retrieve the services `Wisembly\AmqpBundle\GatesBag` to fetch the right gate,
+and then use the `Wisembly\AmqpBundle\Publisher` service to publish a message
+that can be understood by the `CommandProcessor` :
 
 ```php
 use Swarrot\Broker\Message;
 
-$gates = $this->get('wisembly.amqp.gates');
-$gate = $gates['my_gate'];
+use Wisembly\AmqpBundle\GatesBag;
+use Wisembly\AmqpBundle\Publisher;
 
-$publisher = $this->get('wisembly.amqp.publisher);
+// let's say $gates contains the GatesBag service, and
+// $publisher contains the Publisher service
+
+$gate = $gates['my_gate'];
 
 $message = new Message(json_encode([
     'command' => 'symfony:command:to:run',

--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,7 @@
         "symfony/process": "^3.0 || ^4.0",
         "symfony/http-kernel": "^3.0 || ^4.0",
         "symfony/event-dispatcher": "^3.0 || ^4.0",
-        "symfony/dependency-injection": "^3.0 || ^4.0"
+        "symfony/dependency-injection": "^3.3 || ^4.0"
     },
 
     "require-dev": {
@@ -27,6 +27,10 @@
         "pecl-amqp": "PHP AMQP extension",
         "videlalvaro/php-amqplib": "If the pecl is not an option",
         "odolbeau/rabbit-mq-admin-toolkit" : "Configuring automatically your queues, exchanges and bindings"
+    },
+
+    "conflict": {
+        "symfony/dependency-injection": "< 3.3"
     },
 
     "authors": [

--- a/src/Broker/PhpAmqpLibBroker.php
+++ b/src/Broker/PhpAmqpLibBroker.php
@@ -18,7 +18,7 @@ use Wisembly\AmqpBundle\Connection;
 use Wisembly\AmqpBundle\BrokerInterface;
 use Wisembly\AmqpBundle\MessagingException;
 
-class OldsoundBroker implements BrokerInterface
+class PhpAmqpLibBroker implements BrokerInterface
 {
     /** @var AMQPChannel[] */
     private $channels = [];

--- a/src/DependencyInjection/Compiler/BrokerPass.php
+++ b/src/DependencyInjection/Compiler/BrokerPass.php
@@ -8,6 +8,8 @@ use InvalidArgumentException;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
 
+use Wisembly\AmqpBundle\BrokerInterface;
+
 /**
  * Determine and instanciate which RabbitMq Broker to use
  *
@@ -35,6 +37,6 @@ class BrokerPass implements CompilerPassInterface
             throw new InvalidArgumentException(sprintf('Invalid broker "%s". Expected one of those : [%s]', $broker, implode(', ', array_keys($brokers))));
         }
 
-        $container->setAlias('wisembly.amqp.broker', $brokers[$broker]);
+        $container->setAlias(BrokerInterface::class, $brokers[$broker]);
     }
 }

--- a/src/DependencyInjection/Compiler/BrokerPass.php
+++ b/src/DependencyInjection/Compiler/BrokerPass.php
@@ -19,8 +19,14 @@ class BrokerPass implements CompilerPassInterface
     {
         $brokers = [];
 
-        foreach ($container->findTaggedServiceIds('wisembly.amqp.broker') as $id => $tag) {
-            $brokers[isset($tag[0]['alias']) ? $tag[0]['alias'] : $id] = $id;
+        foreach ($container->findTaggedServiceIds('wisembly.amqp.broker') as $id => $tags) {
+            $brokers[$id] = $id;
+
+            foreach ($tags as $tag) {
+                if (isset($tag['alias'])) {
+                    $brokers[$tag['alias']] = &$brokers[$id];
+                }
+            }
         }
 
         $broker = $container->getParameter('wisembly.amqp.broker');

--- a/src/DependencyInjection/WisemblyAmqpExtension.php
+++ b/src/DependencyInjection/WisemblyAmqpExtension.php
@@ -17,6 +17,7 @@ use Wisembly\AmqpBundle\Connection;
 use Wisembly\AmqpBundle\UriConnection;
 
 use Wisembly\AmqpBundle\BrokerInterface;
+use Wisembly\AmqpBundle\Command\ConsumerCommand;
 
 /**
  * This is the class that loads and manages your bundle configuration
@@ -125,7 +126,7 @@ class WisemblyAmqpExtension extends Extension
     {
         $loader->load('commands.xml');
 
-        $definition = $container->getDefinition('wisembly.amqp.command.consumer');
-        $definition->replaceArgument(3, $configuration['console_path']);
+        $definition = $container->getDefinition(ConsumerCommand::class);
+        $definition->replaceArgument('$consolePath', $configuration['console_path']);
     }
 }

--- a/src/DependencyInjection/WisemblyAmqpExtension.php
+++ b/src/DependencyInjection/WisemblyAmqpExtension.php
@@ -12,8 +12,11 @@ use Symfony\Component\HttpKernel\DependencyInjection\Extension;
 
 use Wisembly\AmqpBundle\Gate;
 use Wisembly\AmqpBundle\GatesBag;
+
 use Wisembly\AmqpBundle\Connection;
 use Wisembly\AmqpBundle\UriConnection;
+
+use Wisembly\AmqpBundle\BrokerInterface;
 
 /**
  * This is the class that loads and manages your bundle configuration
@@ -39,6 +42,10 @@ class WisemblyAmqpExtension extends Extension
         $container->getParameterBag()->set('wisembly.amqp.broker', $config['broker']);
 
         $loader->load('profiler.xml');
+
+        $container->registerForAutoconfiguration(BrokerInterface::class)
+            ->addTag('wisembly.amqp.broker')
+        ;
     }
 
     private function registerGates(ContainerBuilder $container, Loader\FileLoader $loader, array $configuration)

--- a/src/DependencyInjection/WisemblyAmqpExtension.php
+++ b/src/DependencyInjection/WisemblyAmqpExtension.php
@@ -1,5 +1,4 @@
 <?php
-
 namespace Wisembly\AmqpBundle\DependencyInjection;
 
 use InvalidArgumentException;
@@ -12,6 +11,7 @@ use Symfony\Component\Config\FileLocator;
 use Symfony\Component\HttpKernel\DependencyInjection\Extension;
 
 use Wisembly\AmqpBundle\Gate;
+use Wisembly\AmqpBundle\GatesBag;
 use Wisembly\AmqpBundle\Connection;
 use Wisembly\AmqpBundle\UriConnection;
 
@@ -91,7 +91,7 @@ class WisemblyAmqpExtension extends Extension
             ;
         }
 
-        $bagDefinition = $container->getDefinition('wisembly.amqp.gates');
+        $bagDefinition = $container->getDefinition(GatesBag::class);
 
         foreach ($configuration['gates'] as $name => $gate) {
             if (null === $gate['connection']) {

--- a/src/DependencyInjection/WisemblyAmqpExtension.php
+++ b/src/DependencyInjection/WisemblyAmqpExtension.php
@@ -36,12 +36,12 @@ class WisemblyAmqpExtension extends Extension
 
         $loader = new Loader\XmlFileLoader($container, new FileLocator(__DIR__.'/../Resources/config'));
 
+        $container->getParameterBag()->set('wisembly.amqp.broker', $config['broker']);
+
         $this->registerGates($container, $loader, $config);
         $this->registerCommands($container, $loader, $config);
 
         $loader->load('brokers.xml');
-        $container->getParameterBag()->set('wisembly.amqp.broker', $config['broker']);
-
         $loader->load('profiler.xml');
 
         $container->registerForAutoconfiguration(BrokerInterface::class)

--- a/src/DependencyInjection/WisemblyAmqpExtension.php
+++ b/src/DependencyInjection/WisemblyAmqpExtension.php
@@ -125,8 +125,6 @@ class WisemblyAmqpExtension extends Extension
     {
         $loader->load('commands.xml');
 
-        $parameterBag = $container->getParameterBag();
-
         $definition = $container->getDefinition('wisembly.amqp.command.consumer');
         $definition->replaceArgument(3, $configuration['console_path']);
     }

--- a/src/Resources/config/amqp.xml
+++ b/src/Resources/config/amqp.xml
@@ -5,13 +5,9 @@
     xsi:schemaLocation="http://symfony.com/schema/dic/services http://symfony.com/schema/dic/services/services-1.0.xsd">
 
     <services>
-        <defaults public="false" />
+        <defaults public="false" autowire="true" autoconfigure="true" />
 
-        <service id="Wisembly\AmqpBundle\Publisher" public="true">
-            <argument type="service" id="Symfony\Component\EventDispatcher\EventDispatcherInterface" />
-            <argument type="service" id="Wisembly\AmqpBundle\BrokerInterface" />
-        </service>
-
+        <service id="Wisembly\AmqpBundle\Publisher" public="true" />
         <service id="Wisembly\AmqpBundle\GatesBag" />
 
         <!-- BC //-->

--- a/src/Resources/config/amqp.xml
+++ b/src/Resources/config/amqp.xml
@@ -5,11 +5,15 @@
     xsi:schemaLocation="http://symfony.com/schema/dic/services http://symfony.com/schema/dic/services/services-1.0.xsd">
 
     <services>
-        <service id="wisembly.amqp.publisher" class="Wisembly\AmqpBundle\Publisher">
-            <argument type="service" id="event_dispatcher" />
-            <argument type="service" id="wisembly.amqp.broker" /> <!-- declared in a compiler pass //-->
+        <service id="Wisembly\AmqpBundle\Publisher">
+            <argument type="service" id="Symfony\Component\EventDispatcher\EventDispatcherInterface" />
+            <argument type="service" id="Wisembly\AmqpBundle\BrokerInterface" />
         </service>
 
-        <service id="wisembly.amqp.gates" class="Wisembly\AmqpBundle\GatesBag" />
+        <service id="Wisembly\AmqpBundle\GatesBag" />
+
+        <!-- BC //-->
+        <service id="wisembly.amqp.publisher" alias="Wisembly\AmqpBundle\Publisher" />
+        <service id="wisembly.amqp.gates" alias="Wisembly\AmqpBundle\GatesBag" />
     </services>
 </container>

--- a/src/Resources/config/amqp.xml
+++ b/src/Resources/config/amqp.xml
@@ -5,9 +5,9 @@
     xsi:schemaLocation="http://symfony.com/schema/dic/services http://symfony.com/schema/dic/services/services-1.0.xsd">
 
     <services>
-        <defaults public="true" />
+        <defaults public="false" />
 
-        <service id="Wisembly\AmqpBundle\Publisher">
+        <service id="Wisembly\AmqpBundle\Publisher" public="true">
             <argument type="service" id="Symfony\Component\EventDispatcher\EventDispatcherInterface" />
             <argument type="service" id="Wisembly\AmqpBundle\BrokerInterface" />
         </service>
@@ -15,7 +15,7 @@
         <service id="Wisembly\AmqpBundle\GatesBag" />
 
         <!-- BC //-->
-        <service id="wisembly.amqp.publisher" alias="Wisembly\AmqpBundle\Publisher" />
-        <service id="wisembly.amqp.gates" alias="Wisembly\AmqpBundle\GatesBag" />
+        <service id="wisembly.amqp.publisher" alias="Wisembly\AmqpBundle\Publisher" public="true" />
+        <service id="wisembly.amqp.gates" alias="Wisembly\AmqpBundle\GatesBag" public="true" />
     </services>
 </container>

--- a/src/Resources/config/amqp.xml
+++ b/src/Resources/config/amqp.xml
@@ -5,6 +5,8 @@
     xsi:schemaLocation="http://symfony.com/schema/dic/services http://symfony.com/schema/dic/services/services-1.0.xsd">
 
     <services>
+        <defaults public="true" />
+
         <service id="Wisembly\AmqpBundle\Publisher">
             <argument type="service" id="Symfony\Component\EventDispatcher\EventDispatcherInterface" />
             <argument type="service" id="Wisembly\AmqpBundle\BrokerInterface" />

--- a/src/Resources/config/brokers.xml
+++ b/src/Resources/config/brokers.xml
@@ -5,6 +5,8 @@
     xsi:schemaLocation="http://symfony.com/schema/dic/services http://symfony.com/schema/dic/services/services-1.0.xsd">
 
     <services>
+        <defaults public="false" />
+
         <service id="Wisembly\AmqpBundle\Broker\PeclBroker">
             <tag name="wisembly.amqp.broker" alias="pecl" />
         </service>
@@ -18,7 +20,5 @@
 
         <!-- BC //-->
         <service id="wisembly.amqp.broker" alias="Wisembly\AmqpBundle\BrokerInterface" />
-        <service id="wisembly.amqp.broker.pecl" alias="Wisembly\AmqpBundle\Broker\PeclBroker" />
-        <service id="wisembly.amqp.broker.oldsound" alias="Wisembly\AmqpBundle\Broker\OldsoundBroker" />
     </services>
 </container>

--- a/src/Resources/config/brokers.xml
+++ b/src/Resources/config/brokers.xml
@@ -5,15 +5,20 @@
     xsi:schemaLocation="http://symfony.com/schema/dic/services http://symfony.com/schema/dic/services/services-1.0.xsd">
 
     <services>
-        <service id="wisembly.amqp.broker.pecl" class="Wisembly\AmqpBundle\Broker\PeclBroker">
+        <service id="Wisembly\AmqpBundle\Broker\PeclBroker">
             <tag name="wisembly.amqp.broker" alias="pecl" />
         </service>
 
-        <service id="wisembly.amqp.broker.oldsound" class="Wisembly\AmqpBundle\Broker\OldsoundBroker">
+        <service id="Wisembly\AmqpBundle\Broker\OldsoundBroker">
             <tag name="wisembly.amqp.broker" alias="oldsound" />
             <tag name="wisembly.amqp.broker" alias="php-amqplib" />
         </service>
 
-        <service id="wisembly.amqp.broker" alias="wisembly.amqp.broker.oldsound" />
+        <service id="Wisembly\AmqpBundle\BrokerInterface" alias="Wisembly\AmqpBundle\Broker\OldsoundBroker" />
+
+        <!-- BC //-->
+        <service id="wisembly.amqp.broker" alias="Wisembly\AmqpBundle\BrokerInterface" />
+        <service id="wisembly.amqp.broker.pecl" alias="Wisembly\AmqpBundle\Broker\PeclBroker" />
+        <service id="wisembly.amqp.broker.oldsound" alias="Wisembly\AmqpBundle\Broker\OldsoundBroker" />
     </services>
 </container>

--- a/src/Resources/config/brokers.xml
+++ b/src/Resources/config/brokers.xml
@@ -11,12 +11,12 @@
             <tag name="wisembly.amqp.broker" alias="pecl" />
         </service>
 
-        <service id="Wisembly\AmqpBundle\Broker\OldsoundBroker">
+        <service id="Wisembly\AmqpBundle\Broker\PhpAmqpLibBroker">
             <tag name="wisembly.amqp.broker" alias="oldsound" />
             <tag name="wisembly.amqp.broker" alias="php-amqplib" />
         </service>
 
-        <service id="Wisembly\AmqpBundle\BrokerInterface" alias="Wisembly\AmqpBundle\Broker\OldsoundBroker" />
+        <service id="Wisembly\AmqpBundle\BrokerInterface" alias="Wisembly\AmqpBundle\Broker\PhpAmqpLibBroker" />
 
         <!-- BC //-->
         <service id="wisembly.amqp.broker" alias="Wisembly\AmqpBundle\BrokerInterface" />

--- a/src/Resources/config/brokers.xml
+++ b/src/Resources/config/brokers.xml
@@ -11,6 +11,7 @@
 
         <service id="wisembly.amqp.broker.oldsound" class="Wisembly\AmqpBundle\Broker\OldsoundBroker">
             <tag name="wisembly.amqp.broker" alias="oldsound" />
+            <tag name="wisembly.amqp.broker" alias="php-amqplib" />
         </service>
 
         <service id="wisembly.amqp.broker" alias="wisembly.amqp.broker.oldsound" />

--- a/src/Resources/config/brokers.xml
+++ b/src/Resources/config/brokers.xml
@@ -5,7 +5,7 @@
     xsi:schemaLocation="http://symfony.com/schema/dic/services http://symfony.com/schema/dic/services/services-1.0.xsd">
 
     <services>
-        <defaults public="false" />
+        <defaults public="false" autowire="true" />
 
         <service id="Wisembly\AmqpBundle\Broker\PeclBroker">
             <tag name="wisembly.amqp.broker" alias="pecl" />

--- a/src/Resources/config/commands.xml
+++ b/src/Resources/config/commands.xml
@@ -5,19 +5,25 @@
     xsi:schemaLocation="http://symfony.com/schema/dic/services http://symfony.com/schema/dic/services/services-1.0.xsd">
 
     <services>
-        <service id="wisembly.amqp.command.consumer" class="Wisembly\AmqpBundle\Command\ConsumerCommand">
-            <tag name="monolog.logger" channel="amqp" />
+        <service id="Wisembly\AmqpBundle\Command\ConsumerCommand">
             <argument type="service" id="logger" on-invalid="null" />
-            <argument type="service" id="wisembly.amqp.broker" />
-            <argument type="service" id="wisembly.amqp.gates" />
+            <argument type="service" id="Wisembly\AmqpBundle\BrokerInterface" />
+            <argument type="service" id="Wisembly\AmqpBundle\GatesBag" />
             <argument /> <!-- console path, filled by extension //-->
+
+            <tag name="console.command" />
+            <tag name="monolog.logger" channel="amqp" />
+        </service>
+
+        <service id="Wisembly\AmqpBundle\Command\PublishCommand">
+            <argument type="service" id="Wisembly\AmqpBundle\Publisher" />
+            <argument type="service" id="Wisembly\AmqpBundle\GatesBag" />
+
             <tag name="console.command" />
         </service>
 
-        <service id="wisembly.amqp.command.publisher" class="Wisembly\AmqpBundle\Command\PublishCommand">
-            <argument type="service" id="wisembly.amqp.publisher" />
-            <argument type="service" id="wisembly.amqp.gates" />
-            <tag name="console.command" />
-        </service>
+        <!-- BC //-->
+        <service id="wisembly.amqp.command.consumer" alias="Wisembly\AmqpBundle\Command\ConsumerCommand" />
+        <service id="wisembly.amqp.command.publisher" alias="Wisembly\AmqpBundle\Command\PublishCommand" />
     </services>
 </container>

--- a/src/Resources/config/commands.xml
+++ b/src/Resources/config/commands.xml
@@ -5,6 +5,8 @@
     xsi:schemaLocation="http://symfony.com/schema/dic/services http://symfony.com/schema/dic/services/services-1.0.xsd">
 
     <services>
+        <defaults public="false" />
+
         <service id="Wisembly\AmqpBundle\Command\ConsumerCommand">
             <argument type="service" id="logger" on-invalid="null" />
             <argument type="service" id="Wisembly\AmqpBundle\BrokerInterface" />

--- a/src/Resources/config/commands.xml
+++ b/src/Resources/config/commands.xml
@@ -5,22 +5,17 @@
     xsi:schemaLocation="http://symfony.com/schema/dic/services http://symfony.com/schema/dic/services/services-1.0.xsd">
 
     <services>
-        <defaults public="false" />
+        <defaults public="false" autowire="true" autoconfigure="true" />
 
         <service id="Wisembly\AmqpBundle\Command\ConsumerCommand">
-            <argument type="service" id="logger" on-invalid="null" />
-            <argument type="service" id="Wisembly\AmqpBundle\BrokerInterface" />
-            <argument type="service" id="Wisembly\AmqpBundle\GatesBag" />
-            <argument /> <!-- console path, filled by extension //-->
+            <argument index="0" type="service" id="Psr\Log\LoggerInterface" on-invalid="null" />
+            <argument index="3" /> <!-- console path, filled by extension //-->
 
             <tag name="console.command" />
             <tag name="monolog.logger" channel="amqp" />
         </service>
 
         <service id="Wisembly\AmqpBundle\Command\PublishCommand">
-            <argument type="service" id="Wisembly\AmqpBundle\Publisher" />
-            <argument type="service" id="Wisembly\AmqpBundle\GatesBag" />
-
             <tag name="console.command" />
         </service>
 

--- a/src/Resources/config/commands.xml
+++ b/src/Resources/config/commands.xml
@@ -8,8 +8,8 @@
         <defaults public="false" autowire="true" autoconfigure="true" />
 
         <service id="Wisembly\AmqpBundle\Command\ConsumerCommand">
-            <argument index="0" type="service" id="Psr\Log\LoggerInterface" on-invalid="null" />
-            <argument index="3" /> <!-- console path, filled by extension //-->
+            <argument type="service" id="Psr\Log\LoggerInterface" on-invalid="null" />
+            <argument key="$consolePath" /> <!-- console path, filled by extension //-->
 
             <tag name="console.command" />
             <tag name="monolog.logger" channel="amqp" />

--- a/src/Resources/config/profiler.xml
+++ b/src/Resources/config/profiler.xml
@@ -5,12 +5,13 @@
     xsi:schemaLocation="http://symfony.com/schema/dic/services http://symfony.com/schema/dic/services/services-1.0.xsd">
 
     <services>
-        <service id="wisembly.amqp.collector" class="Wisembly\AmqpBundle\DataCollector\AMQPDataCollector">
-            <tag name="data_collector" template="WisemblyAmqpBundle:Collector:MessageCollector" id="amqp_collector" />
-        </service>
+        <service id="Wisembly\AmqpBundle\EventListener\MessagingListener">
+            <argument type="service">
+                <service class="Wisembly\AmqpBundle\DataCollector\AMQPDataCollector">
+                    <tag name="data_collector" template="WisemblyAmqpBundle:Collector:MessageCollector" id="amqp_collector" />
+                </service>
+            </argument>
 
-        <service id="wisembly.amqp.subscriber" class="Wisembly\AmqpBundle\EventListener\MessagingListener">
-            <argument type="service" id="wisembly.amqp.collector" />
             <tag name="kernel.event_subscriber" />
         </service>
     </services>

--- a/src/Resources/config/profiler.xml
+++ b/src/Resources/config/profiler.xml
@@ -5,6 +5,8 @@
     xsi:schemaLocation="http://symfony.com/schema/dic/services http://symfony.com/schema/dic/services/services-1.0.xsd">
 
     <services>
+        <defaults public="false" />
+
         <service id="Wisembly\AmqpBundle\EventListener\MessagingListener">
             <argument type="service">
                 <service class="Wisembly\AmqpBundle\DataCollector\AMQPDataCollector">


### PR DESCRIPTION
Let's update to Symfony 3.3 (FQCN ids, autowiring, autoconfiguring, and some cleanups too)

- [x] FQCN ids
- [x] Mark some services as private (even though it's a break, these services have no sense whatsoever to be used from the container)
- [x] Rename oldsound to phpamqplib
- [x] Add some autowiring, autoconfiguring