### PR TITLE
Add a Message helper

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,13 +114,12 @@ and then use the `Wisembly\AmqpBundle\Publisher` service to publish a message
 that can be understood by the `CommandProcessor` :
 
 ```php
-use Swarrot\Broker\Message;
-
+use Wisembly\AmqpBundle\Message;
 use Wisembly\AmqpBundle\Publisher;
 
-$message = new Message(json_encode([
-    'command' => 'symfony:command:to:run',
-    'arguments' => [
+$message = new Message(
+    'symfony:command:to:run',
+    [
         'list',
         'of',
         'arguments'
@@ -128,6 +127,9 @@ $message = new Message(json_encode([
         'options'
     ]
 ]));
+
+// Using swarrot's Swarrot\Broker\Message is also possible if you don't plan on
+// consuming the message through the provider consumer
 
 $publisher->publish($message, 'my_gate');
 // or $publisher->publish($message, $gate); with `$gate` an instanceof Gate

--- a/src/Message.php
+++ b/src/Message.php
@@ -1,0 +1,43 @@
+<?php declare(strict_types=1);
+namespace Wisembly\AmqpBundle;
+
+use Swarrot\Broker\Message as SwarrotMessage;
+
+class Message extends SwarrotMessage
+{
+    /** @var string Command name to execute */
+    private $command;
+
+    /** @var string[] Raw arguments to pass to the command `['-v', '--foo=bar', 'baz']` */
+    private $arguments;
+
+    /** @var ?string stdin to use with the command if any */
+    private $stdin;
+
+    public function __construct(string $command, array $arguments = [], array $properties = [], $id = null)
+    {
+        $this->command = $command;
+        $this->arguments = $arguments;
+
+        parent::__construct(json_encode(
+            [
+                'command' => $command,
+                'arguments' => $arguments,
+                'stdin' => null,
+            ]
+        ), $properties, $id);
+    }
+
+    public function setStdin(?string $stdin): void
+    {
+        $this->stdin = $stdin;
+
+        $this->body = json_encode(
+            [
+                'command' => $this->command,
+                'arguments' => $this->arguments,
+                'stdin' => $stdin
+            ]
+        );
+    }
+}

--- a/src/MessagePublishedEvent.php
+++ b/src/MessagePublishedEvent.php
@@ -5,7 +5,7 @@ use Datetime;
 
 use Symfony\Component\EventDispatcher\Event;
 
-use Swarrot\Broker\Message;
+use Swarrot\Broker\Message as SwarrotMessage;
 
 use Wisembly\AmqpBundle\Gate;
 
@@ -18,7 +18,7 @@ class MessagePublishedEvent extends Event
 {
     const NAME = 'message.published';
 
-    /** @var Message */
+    /** @var SwarrotMessage */
     private $message;
 
     /** @var Datetime */
@@ -27,20 +27,18 @@ class MessagePublishedEvent extends Event
     /** @var Gate */
     private $gate;
 
-    public function __construct(Message $message, Datetime $publishedAt, Gate $gate)
+    public function __construct(SwarrotMessage $message, Datetime $publishedAt, Gate $gate)
     {
         $this->gate        = $gate;
         $this->message     = $message;
         $this->publishedAt = $publishedAt;
     }
 
-    /** @return Message */
-    public function getMessage(): Message
+    public function getMessage(): SwarrotMessage
     {
         return $this->message;
     }
 
-    /** @return Gate */
     public function getGate(): Gate
     {
         return $this->gate;

--- a/src/Publisher.php
+++ b/src/Publisher.php
@@ -5,7 +5,7 @@ use Datetime;
 
 use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 
-use Swarrot\Broker\Message;
+use Swarrot\Broker\Message as SwarrotMessage;
 
 /**
  * Publisher for AMQP Messages
@@ -34,7 +34,7 @@ class Publisher
     /**
      * @param Gate|string $gate Gate to use. If string, will try to fetch it from the gates bag.
      */
-    public function publish(Message $message, $gate): void
+    public function publish(SwarrotMessage $message, $gate): void
     {
         if (!$gate instanceof Gate) {
             $gate = $this->bag->get($gate);

--- a/tests/MessageTest.php
+++ b/tests/MessageTest.php
@@ -1,0 +1,49 @@
+<?php declare(strict_types=1);
+namespace Wisembly\AmqpBundle;
+
+use PHPUnit\Framework\TestCase;
+use Swarrot\Broker\Message as SwarrotMessage;
+
+class MessageTest extends TestCase
+{
+    public function test_it_can_be_instantiated()
+    {
+        $message = new Message('foo');
+
+        $this->assertInstanceOf(Message::class, $message);
+        $this->assertInstanceOf(SwarrotMessage::class, $message);
+    }
+
+    public function test_it_is_converted_to_a_swarrot_message()
+    {
+        $message = new Message('foo');
+
+        $json = <<<'JSON'
+{
+    "command": "foo",
+    "arguments": [],
+    "stdin": null
+}
+JSON;
+
+        $this->assertInstanceOf(SwarrotMessage::class, $message);
+        $this->assertJsonStringEqualsJsonString($json, $message->getBody());
+    }
+
+    public function test_it_rebuilds_body_if_stdin_changes()
+    {
+        $message = new Message('foo');
+        $message->setStdin('bar');
+
+        $json = <<<'JSON'
+{
+    "command": "foo",
+    "arguments": [],
+    "stdin": "bar"
+}
+JSON;
+
+        $this->assertJsonStringEqualsJsonString($json, $message->getBody());
+
+    }
+}

--- a/tests/PublisherTest.php
+++ b/tests/PublisherTest.php
@@ -7,7 +7,7 @@ use Prophecy\Argument;
 
 use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 
-use Swarrot\Broker\Message;
+use Swarrot\Broker\Message as SwarrotMessage;
 use Swarrot\Broker\MessagePublisher\MessagePublisherInterface;
 
 class PublisherTest extends TestCase
@@ -25,7 +25,7 @@ class PublisherTest extends TestCase
 
     public function test_publisher_publishes_messages_and_dispatch_event(): void
     {
-        $message = new Message;
+        $message = new SwarrotMessage;
 
         $connection = new UriConnection('foo', 'amqp://localhost');
         $gate = new Gate($connection, 'foo', 'bar', 'baz');
@@ -55,7 +55,7 @@ class PublisherTest extends TestCase
 
     public function test_publisher_accepts_Gate(): void
     {
-        $message = new Message;
+        $message = new SwarrotMessage;
 
         $connection = new UriConnection('foo', 'amqp://localhost');
         $gate = new Gate($connection, 'foo', 'bar', 'baz');


### PR DESCRIPTION
So that we have a real object construct rather than having to put a `json_encode` in the construct and make our own body.