### PR TITLE
add a int casting for the memory limit option

### DIFF
--- a/src/Command/ConsumerCommand.php
+++ b/src/Command/ConsumerCommand.php
@@ -56,8 +56,14 @@ class ConsumerCommand extends Command
         $gate = $input->getArgument('gate');
         $gate = $this->gates->get($gate);
 
+        $memoryLimit = $input->getOption('memory-limit');
+        // if the memory limit looks like an int, cast it to a strict int
+        if (null !== $input && false !== filter_var($input, FILTER_VALIDATE_INT)) {
+            $memoryLimit = (int) $memoryLimit;
+        }
+
         $options = [
-            'memory_limit' => $input->getOption('memory-limit'),
+            'memory_limit' => $memoryLimit,
             'poll_interval' => $input->getOption('poll-interval'),
             'verbosity' => true === $input->getOption('disable-verbosity-propagation')
                 ? OutputInterface::VERBOSITY_QUIET


### PR DESCRIPTION
The memory limit must be an `int` but the command line gives a `string`:

```
$ php bin/console amqp:consume foo --memory-limit=50
13:57:23 ERROR     [console] Error thrown while running command "amqp:consume foo --memory-limit=50". Message: "The option "memory_limit" with value "50" is expected to be of type "integer" or "null", but is of type "string"." ["error" => Symfony\Component\OptionsResolver\Exception\InvalidOptionsException { …},"command" => "amqp:consume foo --memory-limit=50","message" => "The option "memory_limit" with value "50" is expected to be of type "integer" or "null", but is of type "string"."][]

In OptionsResolver.php line 788:
                                                                                                       
  The option "memory_limit" with value "50" is expected to be of type "integer" or "null", but is of   
  type "string".                                                                                       
```

We have to pass an `int` or `null`. So I decide to cast first, then set `null` if the result is `0`.
Indeed, `0` will always kill the consumer, it's a bad configuration value (see https://github.com/swarrot/swarrot/blob/master/src/Swarrot/Processor/MemoryLimit/MemoryLimitProcessor.php#L41)