### PR TITLE
fix argument sent to monolog error

### DIFF
--- a/src/Processor/CommandProcessor.php
+++ b/src/Processor/CommandProcessor.php
@@ -33,7 +33,7 @@ class CommandProcessor implements ProcessorInterface, ConfigurableInterface
     {
         $body = json_decode($message->getBody(), true);
 
-        $this->logger->info('Dispatching command', $body);
+        $this->logger->info('Dispatching command', ['body' => $body]);
 
         // if no proper command given, log it
         if (!isset($body['command'])) {
@@ -61,7 +61,7 @@ class CommandProcessor implements ProcessorInterface, ConfigurableInterface
                 }
             });
 
-            $this->logger->info('The process was successful', $body);
+            $this->logger->info('The process was successful', ['body' => $body]);
         } catch (ProcessFailedException $e) {
             $this->logger->error('The command failed ; aborting', ['body' => $body, 'code' => $process->getExitCodeText()]);
 


### PR DESCRIPTION
If the `body` is `null`, monolog is currently throwing an exception.