### PR TITLE
give the logger service argument explicitely

### DIFF
--- a/src/Resources/config/amqp.xml
+++ b/src/Resources/config/amqp.xml
@@ -8,6 +8,8 @@
         <defaults public="false" autowire="true" autoconfigure="true" />
 
         <service id="Wisembly\AmqpBundle\Processor\ConsumerFactory">
+            <argument type="service" id="logger" />
+
             <tag name="monolog.logger" channel="amqp" />
         </service>
 

--- a/src/Resources/config/processors.xml
+++ b/src/Resources/config/processors.xml
@@ -8,6 +8,8 @@
         <defaults public="false" autowire="true" autoconfigure="true" />
 
         <service id="Wisembly\AmqpBundle\Processor\CommandProcessor">
+            <argument type="service" id="logger" />
+
             <tag name="monolog.logger" channel="amqp" />
         </service>
 


### PR DESCRIPTION
Currently, the logger auto-wired is the main one (`logger`) and not the configured one with the right channel (`monolog.logger.<channel>`) as expected.